### PR TITLE
Fix switching companies + show companies page

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,3 @@ npm run dev
 ```
 php artisan vendor:publish --tag=filament-companies-views
 ```
-
-
-### Things to Note
-* The package has a bug that I haven't been able to fix.
-* The Current Company only updates to the last recently made company but not the current company that you switch to.. 
-* I believe this might have something to do with the switchable-company.blade.php component.. but could definitely be something else.
-* If you happen to find the problem I would heavily appreciate a pull request of the fix so that I can make this package available through composer. Thanks & Happy Coding!

--- a/src/Http/Controllers/CurrentCompanyController.php
+++ b/src/Http/Controllers/CurrentCompanyController.php
@@ -22,6 +22,6 @@ class CurrentCompanyController extends Controller
             abort(403);
         }
 
-        return redirect(config('fortify.home'), 303);
+        return back();
     }
 }

--- a/stubs/app/Filament/Pages/Companies/Show.php
+++ b/stubs/app/Filament/Pages/Companies/Show.php
@@ -12,4 +12,11 @@ class Show extends Page
     protected static string $view = 'filament.pages.companies.show';
 
     protected static bool $shouldRegisterNavigation = false;
+
+    protected function getViewData(): array
+    {
+        return [
+            'company' => auth()->user()->currentCompany
+        ];
+    }
 }

--- a/stubs/filament/resources/views/filament/pages/companies/show.blade.php
+++ b/stubs/filament/resources/views/filament/pages/companies/show.blade.php
@@ -1,8 +1,4 @@
 <x-filament::page>
-        @if (Wallo\FilamentCompanies\FilamentCompanies::hasCompanyFeatures())
-            @foreach (Auth::user()->allCompanies() as $company)
-            @endforeach
-        @endif
         <div class="mt-10 sm:mt-0">
             @livewire('companies.update-company-name-form', ['company' => $company])
 

--- a/stubs/filament/resources/views/navigation-menu.blade.php
+++ b/stubs/filament/resources/views/navigation-menu.blade.php
@@ -27,7 +27,7 @@
                                     </div>
 
                                     <!-- Company Settings -->
-                                    <x-filament-companies::dropdown-link href="{{ route('filament.pages.show', Auth::user()->currentCompany->id) }}">
+                                    <x-filament-companies::dropdown-link href="{{ route('filament.pages.show') }}">
                                         {{ __('Company Settings') }}
                                     </x-filament-companies::dropdown-link>
 

--- a/tests/CurrentCompanyControllerTest.php
+++ b/tests/CurrentCompanyControllerTest.php
@@ -35,7 +35,7 @@ class CurrentCompanyControllerTest extends OrchestraTestCase
 
         $response = $this->actingAs($user)->put('/current-company', ['company_id' => $company->id]);
 
-        $response->assertRedirect('/home');
+        $response->assertRedirect();
 
         $this->assertEquals($company->id, $user->fresh()->currentCompany->id);
         $this->assertTrue($user->isCurrentCompany($company));


### PR DESCRIPTION
Thank you for sharing your hard-work! I've highlighted the changes I've made that should fix the issue you described in the README , as well as some generic notes below of things that I noticed whilst investigating this issue _(they're mostly opinionated things so really just opinionated suggestions)_.

**Changes**
- Fix show company page
- Refresh the page instead of always sending to home after switching company
- Remove the unnecessary parameter on the edit company page (it assumes you want to edit the currently selected company)

**Notes**
- Tests refused to run for me (I got a bunch of errors even after fixing a few)
- Perhaps some kind of feedback after switching to a different company (maybe a Filament notification)
- Potentially replace actions such as switching companies with Livewire (prevents page from being refreshed)