### PR TITLE
Adds render hooks to the login page

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -7,6 +7,8 @@
         </x-slot>
     @endif
 
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::AUTH_LOGIN_FORM_BEFORE, scopes: $this->getRenderHookScopes()) }}
+
     <x-filament-panels::form wire:submit="authenticate">
         {{ $this->form }}
 
@@ -19,4 +21,6 @@
     @if (Wallo\FilamentCompanies\FilamentCompanies::hasSocialiteFeatures())
         <x-filament-companies::socialite :error-message="$errors->first('filament-companies')" />
     @endif
+
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::AUTH_LOGIN_FORM_AFTER, scopes: $this->getRenderHookScopes()) }}
 </x-filament-panels::page.simple>


### PR DESCRIPTION
Adds support for render hooks on the default login page

cf. https://filamentphp.com/docs/3.x/support/render-hooks