### PR TITLE
Adds render hooks to register page

### DIFF
--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -7,6 +7,8 @@
         </x-slot>
     @endif
 
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::AUTH_REGISTER_FORM_BEFORE, scopes: $this->getRenderHookScopes()) }}
+
     <x-filament-panels::form wire:submit="register">
         {{ $this->form }}
 
@@ -15,6 +17,8 @@
             :full-width="$this->hasFullWidthFormActions()"
         />
     </x-filament-panels::form>
+
+    {{ \Filament\Support\Facades\FilamentView::renderHook(\Filament\View\PanelsRenderHook::AUTH_REGISTER_FORM_AFTER, scopes: $this->getRenderHookScopes()) }}
 
     @if (\Wallo\FilamentCompanies\FilamentCompanies::hasSocialiteFeatures())
         <x-filament-companies::socialite :error-message="$errors->first('filament-companies')" />


### PR DESCRIPTION
When you're adding additional views to your login page, it's likely that you'll need both the events on the login page (added previously here: https://github.com/andrewdwallo/filament-companies/commit/43050a710d6de440782ede06b2df10c3d1cc8adb) as well as the render hooks, included in this branch.