### PR TITLE
Add Filament v5 and Livewire v4 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "filament/filament": "^4.0",
+        "filament/filament": "^4.0|^5.0",
         "illuminate/console": "^11.0|^12.0",
         "illuminate/contracts": "^11.0|^12.0",
         "illuminate/support": "^11.0|^12.0",
@@ -38,7 +38,7 @@
     "require-dev": {
         "laravel/pint": "^1.14",
         "laravel/sanctum": "^4.0",
-        "livewire/livewire": "^3.4.9",
+        "livewire/livewire": "^3.4.9|^4.0",
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^9.0|^10.0",
         "phpunit/phpunit": "^10.5|^11.5.3"

--- a/resources/views/companies/company-employee-manager.blade.php
+++ b/resources/views/companies/company-employee-manager.blade.php
@@ -31,7 +31,7 @@
                         <!-- Role -->
                         @if (count($this->roles) > 0)
                             <x-filament-forms::field-wrapper id="role" statePath="role" required="required" label="{{ __('filament-companies::default.labels.role') }}">
-                                <div x-data="{ role: @entangle('addCompanyEmployeeForm.role') }" class="relative z-0 mt-1 cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700">
+                                <div x-data="{ role: $wire.entangle('addCompanyEmployeeForm.role') }" class="relative z-0 mt-1 cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700">
                                     @foreach ($this->roles as $index => $role)
                                         <button type="button"
                                                 @click="role = '{{ $role->key }}'"
@@ -200,7 +200,7 @@
                 {{ __('filament-companies::default.modal_titles.manage_role') }}
             </x-slot>
 
-            <div x-data="{ role: @entangle('currentRole') }"
+            <div x-data="{ role: $wire.entangle('currentRole') }"
                  class="relative z-0 mt-1 cursor-pointer rounded-lg border border-gray-200 dark:border-gray-700">
                 @foreach ($this->roles as $index => $role)
                     <button type="button"


### PR DESCRIPTION
## Summary
- Update `filament/filament` constraint from `^4.0` to `^4.0|^5.0`
- Update `livewire/livewire` constraint from `^3.4.9` to `^3.4.9|^4.0`
- Replace deprecated `@entangle` Blade directive with `$wire.entangle()` in `company-employee-manager.blade.php`

## Livewire v4 @entangle Deprecation

The `@entangle` Blade directive is [deprecated in Livewire v4](https://livewire.laravel.com/docs/4.x/alpine#sharing-state-using-wire-entangle) and causes issues when removing DOM elements. The recommended replacement is `$wire.entangle()` which works in both Livewire v3 and v4.

## Test plan
- [x] Full test suite passes (2198 tests, 0 failures) on a project using Filament v5.2.0 + Livewire v4.1.3
- [x] Backward compatible with Filament v4 + Livewire v3